### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/router/index.js
+++ b/lib/router/index.js
@@ -8,7 +8,7 @@ var Writable = require('stream').Writable;
 var QS = require('querystring');
 var _ = require('lodash');
 var Express = require('express');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var buildReq = require('./req');
 var buildRes = require('./res');

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "method-override": "~2.3.0",
     "mock-req": "0.1.0",
     "mock-res": "0.1.0",
-    "node-uuid": "~1.4.0",
     "pluralize": "~0.0.5",
     "prompt": "~0.2.13",
     "rc": "~0.5.0",
@@ -61,7 +60,8 @@
     "semver": "^4.3.2",
     "skipper": "~0.5.5",
     "t1bao-waterline": "0.0.2",
-    "uid-safe": "^1.0.1"
+    "uid-safe": "^1.0.1",
+    "uuid": "^3.0.0"
   },
   "description": "API-driven framework for building realtime apps, using MVC conventions (based on Express and Socket.io)",
   "devDependencies": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.